### PR TITLE
missing sudo su

### DIFF
--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -10,6 +10,7 @@ The following instructions assume:
 
 To quickly install a default IntelMQ + Manager with no password just run the following as root:
 ```
+sudo su -
 git clone https://<your-github-account>@github.com/certtools/intelmq-manager.git /tmp/intelmq-manager
 /tmp/intelmq-manager/bin/INSTALL_INTELMQ.sh
 /tmp/intelmq-manager/bin/INSTALL_MANAGER.sh


### PR DESCRIPTION
Even if it is mentioned in the sentence above, it is handy to have it in the command line part.

If not you will end up with:

sh INSTALL_MANAGER.sh  USER
Installing dependencies
E: Could not open lock file /var/lib/apt/lists/lock - open (13: Permission denied)
E: Unable to lock directory /var/lib/apt/lists/
E: Could not open lock file /var/lib/dpkg/lock - open (13: Permission denied)
E: Unable to lock the administration directory (/var/lib/dpkg/), are you root?
E: Could not open lock file /var/lib/dpkg/lock - open (13: Permission denied)
E: Unable to lock the administration directory (/var/lib/dpkg/), are you root?
Downloading and copying IntelMQ Manager
fatal: destination path '/tmp/intelmq-manager' already exists and is not an empty directory.
cp: target '/var/www/' is not a directory
chown: cannot access '/var/www/': No such file or directory
Adding www-data to intelmq group
usermod: Permission denied.
usermod: cannot lock /etc/passwd; try again later.
INSTALL_MANAGER.sh: 17: INSTALL_MANAGER.sh: cannot create /etc/sudoers: Permission denied