### PR TITLE
modify default.conf of apache

### DIFF
--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -50,6 +50,11 @@ Edit '/var/www/php/config.php' and put the following as the $CONTROLLER value:
 $CONTROLLER = "sudo -u intelmq /usr/local/bin/intelmqctl %s";
 ```
 
+Edit '/etc/apache2/sites-available/000-default.conf' and change the DocumentRoot to
+```
+ DocumentRoot /var/www/
+```
+
 Restart apache:
 ```
 /etc/init.d/apache2 restart


### PR DESCRIPTION
Running a default installation will end up with an apache config stating DocumentRoot /var/www/html
but in /var/www/html there is only:
intelmq@intelmq:/var/www/html$ ls -hall
total 20K
drwxr-xr-x 2 www-data www-data 4.0K Mar 10 16:19 .
drwxr-xr-x 8 www-data www-data 4.0K Mar 10 16:19 ..
-rw-r--r-- 1 www-data www-data  12K Mar 10 16:19 index.html

I gues this should be changed to /var/www:
intelmq@intelmq:/var/www$ ls
about.html  configs.html  html    index.html  management.html  php
blank.html  css           images  js          monitor.html     plugins