### PR TITLE
Temporary fix for save.php

### DIFF
--- a/intelmq-manager/php/save.php
+++ b/intelmq-manager/php/save.php
@@ -1,25 +1,26 @@
 <?php
-    
+
     require('config.php');
-    
-    if (array_key_exists($_GET['file'], $FILES)) {
+
+    $file = $_GET['file'];
+    if (array_key_exists($file, $FILES)) {
         $filename = $FILES[$_GET['file']];
     }
-    
+
     $post_contents = file_get_contents("php://input");
-    
-    $decoded_config = json_decode($post_contents);
-    
-    foreach ($decoded_config as $key => $value) {
-        if(preg_match($BOT_ID_REJECT_REGEX, $key)) {
-            die('Invalid bot ID');
-        }
+
+    $data = json_decode($post_contents, true);
+
+    foreach ($data as $key => $obj) {
+        if(($file == "startup") && (strpos($key, '__default__') !== false)) { unset($data[$key]); }
     }
-    
+
+/*
     if(preg_match_all($BOT_CONFIGS_REJECT_REGEX, $post_contents, $matches)) {
         die('Config has invalid characters');
     }
-    
-    file_put_contents($filename, $post_contents);
-    
+*/
+
+    file_put_contents($filename, json_encode($data, JSON_PRETTY_PRINT));
+
 ?>


### PR DESCRIPTION
___default___ = _ _ _ default _ _ _ (with no spaces)
There is a problem with this file because it executes die() function.
In startup.conf and runtime.conf is definied "__default__" and it executes die() function. That's why only pipeline.conf is saved (no "__default__" definition).

"__default__" matches $BOT_ID_REJECT_REGEX (/[^A-Za-z0-9.-]/)

Here is small (temporary) fix.
__default__ must be declared in runtime.conf, but it cannot be declared in startup.conf.

