### PR TITLE
BUG: Remove line number form log

### DIFF
--- a/intelmq-manager/js/monitor.js
+++ b/intelmq-manager/js/monitor.js
@@ -12,7 +12,6 @@ $('#log-table').dataTable({
     pageLength: 10,
     order: [0, 'desc'],
     columns: [
-        { "data": "line_number" },
         { "data": "date" },
         { "data": "bot_id" },
         { "data": "log_level" },

--- a/intelmq-manager/monitor.html
+++ b/intelmq-manager/monitor.html
@@ -136,7 +136,7 @@
                                 <div class="table-responsive">
                                     <table class="table" id="log-table">
                                         <thead>
-                                            <tr><th>#Line</th><th>Time</th><th>ID</th><th>Level</th><th>Message</th><th></th></tr>
+                                            <tr><th>Time</th><th>ID</th><th>Level</th><th>Message</th><th></th></tr>
                                         </thead>
                                         <tbody id="log-table-body">
                                         </tbody>


### PR DESCRIPTION
Not provided anymore by intelmqctl, as logs are read backwards.

See 9cd3205759f17182371919cf9a591e35eabc3f16 in certools/intelmq: certtools/intelmq#277