### PR TITLE
ENH: new bot: automatically remove invalid chars for bot name

### DIFF
--- a/intelmq-manager/js/main.js
+++ b/intelmq-manager/js/main.js
@@ -222,7 +222,7 @@ function fill_bot(id, group, name) {
         element.setAttribute('type', 'text');
         element.setAttribute('id', 'node-id');
         
-        name = bot['name'].replace(/\ /g,'-')
+        name = bot['name'].replace(/\ /g,'-').replace(/[^A-Za-z0-9-]/g,'')
         group = bot['group'].replace(/\ /g,'-')
         default_id = name + "-" + group
         


### PR DESCRIPTION
Some bots contain dots in their name by default (e.g. blocklist.de)
But as the dot is not a valid char for the bot id.
All invalid chars are now removed by default for the bot-id

fixes #58 

Had this fix already some time in my local working copy.