### PR TITLE
UX: remove colon from panel heading in management

### DIFF
--- a/intelmq-manager/management.html
+++ b/intelmq-manager/management.html
@@ -81,7 +81,7 @@
                     <div class="col-md-2">
                         <div class="panel panel-default" id="botnet-status-panel">
                             <div class="panel-heading">
-                                <h4 id="botnet-status-panel-title">Botnet Status:<h4>
+                                <h4 id="botnet-status-panel-title">Botnet Status<h4>
                             </div>
                             <div class="panel-body">
                                 <div class="panel-div">Status: <span id="botnet-status" class="bg-warning">Unknown</span></div><div id="botnet-buttons"></div>
@@ -91,7 +91,7 @@
                     <div class="col-md-10">
                         <div class="panel panel-default" id="bot-table-panel">
                             <div class="panel-heading">
-                                <h4 id="bot-status-panel-title">Individual Bot Status:<h4>
+                                <h4 id="bot-status-panel-title">Individual Bot Status<h4>
                             </div>
                             <div class="panel-body">
                                 <div class="table-responsive">


### PR DESCRIPTION
To keep consistency with other pages