### PR TITLE
Bugfix: save configuration at configs.html#new page

### DIFF
--- a/intelmq-manager/js/main.js
+++ b/intelmq-manager/js/main.js
@@ -1,3 +1,4 @@
+var defaults = {};
 var nodes = {};
 var edges = {};
 var bots = {};


### PR DESCRIPTION
Fixes state, when at configs.html#new page save configuration does not work, because `defaults` variable is not defined.