### PR TITLE
Fixed dataTable header

### DIFF
--- a/intelmq-manager/css/sb-admin-2.css
+++ b/intelmq-manager/css/sb-admin-2.css
@@ -232,7 +232,9 @@ body {
 
 table.dataTable thead .sorting,
 table.dataTable thead .sorting_asc,
-table.dataTable thead .sorting_desc,
+table.dataTable thead .sorting_desc {
+  background: transparent;
+}
 
 table.dataTable thead .sorting_asc:after {
     content: "\f0de";


### PR DESCRIPTION
Without this fix, content, float and font-family CSS options are applied also on whole `th` element and not only to after pseudoelement