### PR TITLE
bug fix: JSON parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,10 +14,12 @@ CHANGELOG
 - "Save Configuration" button reloads the bots whose destination queues changed (#175).
 - Allow standard vis.js arrow and +/- navigation when network chart is focused (#176).
 - Underscored letters denote shortcuts - you can now edit the network without wandering the mouse all around the screen (#176).
+- Correctly load JSON parameters when editing a bot: content instead of '[object Object]' string.
 
 #### Management
 
 #### Monitor
+- Correctly display JSON parameters: content instead of '[object Object]' string.
 
 #### Check
 

--- a/intelmq-manager/js/configs.js
+++ b/intelmq-manager/js/configs.js
@@ -451,6 +451,9 @@ function insertKeyValue(key, value, section, allowXButtons, insertAt) {
     valueCell.appendChild(valueInput);
 
     keyCell.innerHTML = key;
+    if (value !== null && typeof value === "object") {
+               value = JSON.stringify(value);
+    }
     valueInput.setAttribute('value', value);
 }
 

--- a/intelmq-manager/js/monitor.js
+++ b/intelmq-manager/js/monitor.js
@@ -401,9 +401,13 @@ function refresh_configuration_info(bot_id) {
     }
     var params = app.nodes[bot_id].parameters;
     for (let key in params) {
-        $el = $("<li><b>" + key + "</b>: " + params[key] + "</li>");
-        if (params[key].indexOf && params[key].indexOf(ALLOWED_PATH) === 0) {
-            let url = LOAD_CONFIG_SCRIPT + "?file=" + params[key];
+        let param = params[key];
+        if (param !== null && typeof value === "object") { // display json/list instead of "[Object object]"
+            param = JSON.stringify(param);
+        }
+        $el = $(`<li><b>${key}</b>: ${param}</li>`);
+        if (param && param.indexOf && param.indexOf(ALLOWED_PATH) === 0) {
+            let url = LOAD_CONFIG_SCRIPT + "?file=" + param;
             $.getJSON(url, (data) => {
                 let html = "";
                 if (data.directory) {


### PR DESCRIPTION
Before when I saved a JSON-like string as a bot parameter in Manager and reloaded the page, I got displayed [object Object] because it was internally converted to a JSON:

![image](https://user-images.githubusercontent.com/6942231/50607719-732ca880-0eca-11e9-9323-a020d1348b2f.png)

Now that's fixed both on Configuration and Monitor page:

![image](https://user-images.githubusercontent.com/6942231/50607689-5f814200-0eca-11e9-8a5d-95052ddde894.png)


![image](https://user-images.githubusercontent.com/6942231/50607679-57290700-0eca-11e9-8519-2d9078a48a28.png)
