### PR TITLE
bot reloads after save

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ CHANGELOG
 #### Landing page
 
 #### Configuration
+- "Save Configuration" button reloads the bots whose destination queues changed.
 
 #### Management
 

--- a/README.md
+++ b/README.md
@@ -22,9 +22,9 @@ When you add a node or edit one you'll be presented with a form with the availab
 
 ![Parameter editing](docs/screenshots/configuration2.png?raw=true "Parameter editing")
 
-After editing the bots' configuration and pipeline, simply click "Save Configuration" to automatically write the changes to the correct files.  The configurations are now ready to be deployed. 
+After editing the bots' configuration and pipeline, simply click "Save Configuration" to automatically write the changes to the correct files.  The configurations are now ready to be deployed.
 
-**Note well**: if you do not press "Save Configuration" your changes will be lost whenever you reload the web page or move between different tabs within the intelmq manager page.
+**Note well**: if you do not press "Save Configuration" your changes will be lost whenever you reload the web page or move between different tabs within the IntelMQ manager page.
 
 #### Botnet Management
 When you save a configuration you can go to the 'Management' section to see what bots are running and start/stop the entire botnet, or a single bot.

--- a/intelmq-manager/js/network-configuration.js
+++ b/intelmq-manager/js/network-configuration.js
@@ -125,12 +125,12 @@ var NETWORK_OPTIONS = {
             }
 
             app.edges[data.id] = {'from': data.from, 'to': data.to};
-            $saveButton.blinking();
+            $saveButton.blinking(data.from);
         },
         deleteEdge: function (data, callback) {
+            $saveButton.blinking(app.edges[data["edges"][0]].from);
             delete app.edges[data["edges"][0]];
             callback(data);
-            $saveButton.blinking();
         }
     },
     layout: {


### PR DESCRIPTION
When adding queues, one can be surprised that no messages are piped through after a successful save. You have to reload the bots their destination queues changed.
Now, the saving button note IDs of changed bots and after save, it reloads them automatically. In case of success, message "Successfully reloaded bots: ..." appears.

![image](https://user-images.githubusercontent.com/6942231/50809476-fb181580-1303-11e9-8a81-8bd5465eb446.png)

(The functionality works for adding new queues and removing old ones and perform uniques the list of bots so that no bot is superfluously reloaded twice.)