### PR TITLE
Disable physics in network view by default

### DIFF
--- a/intelmq-manager/js/configs.js
+++ b/intelmq-manager/js/configs.js
@@ -753,7 +753,9 @@ function initNetwork(includePositions = true) {
             reload_queues.start();
         }
     }).click();
-    let physics_running = true;
+    let physics_running = false;
+    app.network.setOptions({physics: (physics_running = false)});
+    $(".vis-physics-toggle", $nc).toggleClass("running");
     $(".vis-physics-toggle", $nc).click(function () {
         $(this).toggleClass("running");
         app.network.setOptions({physics: (physics_running = !physics_running)});


### PR DESCRIPTION
In newer versions of intelmq-manager, the positions of the bots in the network view can be saved. However, with 'physics' being enabled by default, the view of larger networks immediately gets screwed up after reloading (e.g. overlapping edges).

So I'd like to propose to disable physics by default. If needed/wanted, it can be enabled with a single click.

The default setting for 'physics' (and 'live'?) could be set in a configuration file for intelmq-manager in the future.