### PR TITLE
physics / live settings remembered on server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ CHANGELOG
 - Underscored letters denote shortcuts - you can now edit the network without wandering the mouse all around the screen (#176).
 - Correctly load JSON parameters when editing a bot: content instead of '[object Object]' string.
 - Handle not explicitly given internal queues.
+- Physics / Live button are now rememberable in the positions.conf file on the server.
 
 #### Management
 

--- a/intelmq-manager/js/positions.js
+++ b/intelmq-manager/js/positions.js
@@ -1,19 +1,28 @@
 var app = app || {};
+
 function generate_positions_conf() {
     var new_positions = app.network.getPositions();
     new_positions = sortObjectByPropertyName(new_positions);
 
+    new_positions["settings"] = settings;
     return JSON.stringify(new_positions, undefined, 4);
 }
 
 function read_positions_conf(config) {
+    if("settings" in config) { // reload settings
+        settings = config["settings"];
+        if (settings.physics === null) {
+            settings.physics = Object.keys(app.nodes).length < 40; // disable physics by default when there are more then 40 bots
+        }
+        delete config["settings"];
+    }
     return config;
 }
 
 function getNodeData(data) {
     var networkNodes = [];
 
-    data.forEach(function(elem, index, array) {
+    data.forEach(function (elem, index, array) {
         networkNodes.push({id: elem.id, label: elem.id, x: elem.x, y: elem.y});
     });
 

--- a/intelmq-manager/js/static.js
+++ b/intelmq-manager/js/static.js
@@ -66,6 +66,11 @@ var MONITOR_BOT_URL = "?page=monitor&bot_id={0}";
 
 var page_is_exiting = false;
 
+var settings = {
+    physics : null, // by default, physics is on depending on bot count
+    live : true, // by default on
+};
+
 $(window).on('unload', function () {
     page_is_exiting = true;
 });

--- a/intelmq-manager/php/load_configs.php
+++ b/intelmq-manager/php/load_configs.php
@@ -1,7 +1,6 @@
 <?php
 
 require('config.php');
-
 if (array_key_exists($_GET['file'], $FILES)) {
     // standard whitelisted config file
     header('Content-Type: application/json');

--- a/intelmq-manager/plugins/vis.js/vis.css
+++ b/intelmq-manager/plugins/vis.js/vis.css
@@ -611,28 +611,15 @@ div.vis-network div.vis-save {
   user-select: none;
 }
 
-div.vis-network div.vis-save-blinking {
-  border-radius: 10px;
-  position:absolute;
-  right: -10px;
-  top: 35px;
-  white-space: nowrap;
-  padding-bottom: 5px;
-  padding-left: 5px;
-  padding-top: 5px;
-
-  cursor: pointer;
-  -webkit-touch-callout: none;
-  -webkit-user-select: none;
-  -khtml-user-select: none;
-  -moz-user-select: none;
-  -ms-user-select: none;
-  user-select: none;
-
+div.vis-network div.vis-save.vis-save-blinking {
   -webkit-animation: blinking 1500ms infinite;
   -moz-animation: blinking 1500ms infinite;
   -o-animation: blinking 1500ms infinite;
   animation: blinking 1500ms infinite;
+}
+
+div.vis-network div.vis-save.blinking-once {
+    animation: blinking 1000ms 2;
 }
 
 div.vis-network div.vis-save:hover {

--- a/intelmq-manager/templates/configs.html
+++ b/intelmq-manager/templates/configs.html
@@ -122,7 +122,7 @@
                 Live
             </div>
         </div>
-        <div class="vis-physics-toggle running">
+        <div class="vis-physics-toggle">
             <div data-accesskey="p" class="icon fa-align-right fa">
                 Physics
             </div>


### PR DESCRIPTION
closes #177 

You can now remember the settings. When clicked live or physics button, save button blinks twice (only). When saved, settings is put alongside positions, in the same positions.conf file. You may prefer to put it in another file but I think this would be an overhead to fetch two files.

If not set, physics is by default on for botnets with 40 bots or less.