### PR TITLE
multiple edges between same nodes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ CHANGELOG
 - Handle not explicitly given internal queues.
 - Physics / Live button are now rememberable in the positions.conf file on the server.
 - When changing state or being disabled or erroneous, bot receives dashed border.
+- You are allowed to create multiple edges between the same nodes - correctly displayed. If the edges should have the same paths, rename dialog appears.
 
 #### Management
 - Clicking an action on a bot will make group pane correspond immediately

--- a/intelmq-manager/js/configs.js
+++ b/intelmq-manager/js/configs.js
@@ -276,15 +276,25 @@ function save_data_on_files() {
 // Prepare data from configuration files to be used in Vis
 
 function convert_edges(edges) {
-    var new_edges = [];
-
-    for (index in edges) {
-        var new_edge = {};
+    let new_edges = [];
+    let roundness = {};
+    for (let index in edges) {
+        let new_edge = {};
         new_edge.id = edges[index]['id'];
         new_edge.from = edges[index]['from'];
         new_edge.to = edges[index]['to'];
-
         new_edge.label = edges[index]['path'];
+
+        // if there is multiple edges between nodes we have to distinguish them manually, see https://github.com/almende/vis/issues/1957
+        let hash = new_edge.from + new_edge.to;
+        if (hash in roundness) {
+            roundness[hash] += 0.3;
+        } else {
+            roundness[hash] = 0;
+        }
+        if (roundness[hash]) {
+            new_edge.smooth = {type: "curvedCCW", "roundness": roundness[hash]};
+        }
 
         new_edges.push(new_edge);
     }

--- a/intelmq-manager/js/network-configuration.js
+++ b/intelmq-manager/js/network-configuration.js
@@ -97,16 +97,30 @@ var NETWORK_OPTIONS = {
                 return;
             }
 
-            for (index in app.edges) {
+            let edit_needed = false; // there is path name clash
+            let occupied_values = new Set(); // prevent edges from overlapping
+            let roundness = 0;
+            for (let index in app.edges) {
                 if (app.edges[index].from == data.from && app.edges[index].to == data.to) {
-                    show_error('There is already a link between those bots');
-                    return;
+                    let smooth = app.network_data.edges.get(index).smooth;
+                    occupied_values.add(smooth? smooth.roundness : 0);
+
+                    if (app.edges[index].path == data.path) {
+                        show_error('There is already a link between those bots with the same path, rename.');
+                        edit_needed = true;
+                    }
                 }
             }
+            if (occupied_values) {
+                while(occupied_values.has(roundness)) {
+                    roundness += 0.3;
+                }
+                data.smooth = {'type': 'curvedCCW', 'roundness': roundness};
+            }
 
-            var neighbors = ACCEPTED_NEIGHBORS[app.nodes[data.from].group];
-            var available_neighbor = false;
-            for (index in neighbors) {
+            let neighbors = ACCEPTED_NEIGHBORS[app.nodes[data.from].group];
+            let available_neighbor = false;
+            for (let index in neighbors) {
                 if (app.nodes[data.to].group == neighbors[index]) {
                     callback(data);
                     available_neighbor = true;
@@ -126,9 +140,11 @@ var NETWORK_OPTIONS = {
             if (app.edges[data.id] === undefined) {
                 app.edges[data.id] = {};
             }
-
             app.edges[data.id] = {'from': data.from, 'to': data.to};
             $saveButton.blinking(data.from);
+            if (edit_needed) {
+                editPath(app, data.id, true);
+            }
         },
         deleteEdge: function (data, callback) {
             $saveButton.blinking(app.edges[data["edges"][0]].from);
@@ -142,20 +158,58 @@ var NETWORK_OPTIONS = {
     }
 };
 
-
 /**
- * Setting path name.
+ * Setting path name of a queue. If path already exists between bots, dialog re-appears.
+ * If cancelled, previous path name is restored, or queue is deleted (if was just being added).
  * As this is not a standard-vis function, it has to be a separate method.
+ *
+ * @param app
+ * @param edge id of the edge
+ * @param adding True if edge is just being added (and shall be removed if we fail to provide a unique path name).
  */
-function editPath(app, edge) {
-    let $input = $("<input/>", {"placeholder": "_default", "val": app.edges[edge]["path"]});
+function editPath(app, edge, adding=false) {
+    let ok_clicked = false;
+    let data = app.edges[edge];
+    data.original_path = data.original_path  || data.path || true;
+    console.log('169: "orig path"(): ', "orig path", data);
+    let $input = $("<input/>", {"placeholder": "_default", "val": data.path});
     popupModal("Set the edge name", $input, () => {
-        if(app.edges[edge]["path"] === $input.val()) {
+        ok_clicked = true;
+        console.log('161: 1, data["path"], $input.val()(): ', 1, data.path, $input.val());
+        if (data.path === $input.val()) {
+            console.log('163: 2(): ', 2);
             return;
         }
-        app.edges[edge]["path"] = $input.val();
+        console.log('166: 3(): ', 3);
+        data.path = $input.val();
+        if (!data.path) {
+            delete data.path;
+        }
         app.network_data.edges.update({"id": edge, "label": $input.val()});
         $saveButton.blinking();
+    }).on("hide.bs.modal", () => {
+        for (let index in app.edges) {
+            if (index !== edge &&
+                app.edges[index].from == data.from &&
+                app.edges[index].to == data.to &&
+                app.edges[index].path == data.path) {
+                let path_name = data.path || "_default";
+                if (ok_clicked) {
+                    show_error(`Could not add the queue ${path_name}, there already is such queue.`);
+                    return editPath(app, edge, adding);
+                } else if(adding) {
+                    show_error(`Removing duplicate edge ${path_name}.`);
+                    app.network_data.edges.remove({"id": edge});
+                    delete app.edges[edge];
+                } else {
+                    data.path = (data.original_path === true)?undefined:data.original_path;
+                    show_error(`Restoring original path name.`);
+                    app.network_data.edges.update({"id": edge, "label": data.path});
+                }
+            }
+
+        }
+    delete data.original_path;
     });
 }
 


### PR DESCRIPTION
Usecase: Sieve – some events go to the DB, and some need to go to a special place and to the DB at once. It should be then possible to have multiple pipes between the same bots.

![image](https://user-images.githubusercontent.com/6942231/56002897-94b8df80-5cc4-11e9-81e7-9edcf644e64a.png)
