### PR TITLE
JSON auto-slash fix certtools/intelmq#1579

### DIFF
--- a/intelmq-manager/js/configs.js
+++ b/intelmq-manager/js/configs.js
@@ -537,7 +537,11 @@ function saveFormData() {
         var value = null;
 
         try {
-            value = JSON.parse(valueInput.value);
+            // In order '{"time.source":"\*"}' would be treated as an object,
+            // we have to translate it to '{"time.source":"\\*"}' first.
+            // In the runtime.conf, it will appear as '{"time.source":"\\*"}'
+            // which is identical to the raw string '{"time.source": r"\*"}'.
+            value = JSON.parse(valueInput.value.replace(/\\/g,'\\\\'));
         } catch (err) {
             value = valueInput.value;
         }


### PR DESCRIPTION
Doubles all backslashes in the bot dict-like parameters.

In order `{"time.source":"\*"}` would be treated as an object, we have to translate it to `{"time.source":"\\*"}` first. In web console, it will appear as `{"time.source":"\*"}`, whereas in the runtime.conf, it will appear as `{"time.source":"\\*"}` which is identical to the raw string `{"time.source": r"\*"}`.