### PR TITLE
Remove the custom sdist command and run the html build every time

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,5 @@
 #!/usr/bin/python3
 from setuptools import find_packages, setup
-from setuptools.command.sdist import sdist as _sdist
 
 import pathlib
 import shutil
@@ -8,49 +7,41 @@ from mako.lookup import TemplateLookup
 
 from intelmq_manager.version import __version__
 
-class CustomSdist(_sdist):
-    """ Custom source dist command to build html files."""
 
+def render_page(pagename: str) -> str:
     template_dir = pathlib.Path("intelmq_manager/templates")
     template_lookup = TemplateLookup(directories=[template_dir], default_filters=["h"])
+    template = template_lookup.get_template(pagename + ".mako")
+    controller_cmd = "intelmq"
+    allowed_path = "/opt/intelmq/var/lib/bots/"
+    return template.render(pagename=pagename,
+            controller_cmd=controller_cmd,
+            allowed_path=allowed_path)
 
+def buildhtml():
+    outputdir = pathlib.Path('intelmq_manager/html')
+    outputdir.mkdir(parents=True, exist_ok=True)
 
-    def render_page(self, pagename: str) -> str:
-        template = self.template_lookup.get_template(pagename + ".mako")
-        controller_cmd = "intelmq"
-        allowed_path = "/opt/intelmq/var/lib/bots/"
-        return template.render(pagename=pagename,
-                controller_cmd=controller_cmd,
-                allowed_path=allowed_path)
+    htmlfiles = ["configs", "management", "monitor", "check", "about", "index"]
+    for filename in htmlfiles:
+        print("Rendering {}.html".format(filename))
+        html = render_page(filename)
+        with outputdir.joinpath("{}.html".format(filename)) as p:
+            p.write_text(html)
 
-    def build(self):
-        outputdir = pathlib.Path('intelmq_manager/html')
-        outputdir.mkdir(parents=True, exist_ok=True)
+    staticfiles = ["css", "images", "js", "plugins", "less"]
+    for filename in staticfiles:
+        print("Copying {} recursively".format(filename))
+        src = pathlib.Path('intelmq_manager/static/{}'.format(filename))
+        dst = outputdir.joinpath(filename)
+        if dst.exists():
+            shutil.rmtree(dst)
+        shutil.copytree(src, dst)
 
-        htmlfiles = ["configs", "management", "monitor", "check", "about", "index"]
-        for filename in htmlfiles:
-            print("Rendering {}.html".format(filename))
-            html = self.render_page(filename)
-            with outputdir.joinpath("{}.html".format(filename)) as p:
-                p.write_text(html)
-
-        staticfiles = ["css", "images", "js", "plugins", "less"]
-        for filename in staticfiles:
-            print("Copying {} recursively".format(filename))
-            src = pathlib.Path('intelmq_manager/static/{}'.format(filename))
-            dst = outputdir.joinpath(filename)
-            if dst.exists():
-                shutil.rmtree(dst)
-            shutil.copytree(src, dst)
-
-    def run(self):
-        self.build()
-        return _sdist.run(self)
+# Before running setup, we build the html files in any case
+buildhtml()
 
 setup(
-    cmdclass = {
-        'sdist': CustomSdist,
-        },
     name="intelmq-manager",
     version=__version__,
     python_requires='>=3.5',


### PR DESCRIPTION
As it turns out, overriding the sdist command of setuptools is not
the best way to build the html files, because it is not used when
building a binary package- thats done without generating a source
before. Therefore the html build stage is now done in setup.py on
any run.
