### PR TITLE
Update links in the webinterface to point to static files

### DIFF
--- a/intelmq_manager/static/js/static.js
+++ b/intelmq_manager/static/js/static.js
@@ -65,7 +65,7 @@ var LOAD_X_LOG_LINES = 30;
 
 var MESSAGE_LENGTH = 200;
 
-var MONITOR_BOT_URL = "?page=monitor&bot_id={0}";
+var MONITOR_BOT_URL = "monitor.html?bot_id={0}";
 
 var page_is_exiting = false;
 

--- a/intelmq_manager/templates/base.mako
+++ b/intelmq_manager/templates/base.mako
@@ -83,14 +83,14 @@
             <!-- Navigation -->
             <nav class="navbar navbar-default navbar-static-top" role="navigation" style="margin-bottom: 0">
                 <div class="navbar-header">
-                    <a class="navbar-brand" href="?page=index"><img height="24px"  style="margin-right:10px; display:inline" src="./images/logo2.png"><img height="20px" src="./images/logo_no_margin_6.png" style="display:inline"/></a>
+                    <a class="navbar-brand" href="index.html"><img height="24px"  style="margin-right:10px; display:inline" src="./images/logo2.png"><img height="20px" src="./images/logo_no_margin_6.png" style="display:inline"/></a>
                 </div>
                 <!-- /.navbar-header -->
 
                 <ul class="nav navbar-top-links navbar-left">
                     % for page in pages:
                     <li class="${'active' if pagename == page.name else ''}">
-                        <a href="?page=${page.name}">
+                        <a href="${page.name}.html">
                             <span class="top-menu-text"><img src="./images/${page.icon}" width="24px" height="24px">&nbsp;${page.title}</span>
                         </a>
                     </li>

--- a/intelmq_manager/templates/index.mako
+++ b/intelmq_manager/templates/index.mako
@@ -17,7 +17,7 @@
         <div class="row center-row">
             <div class="col-md-9 col-sm-12 center-row-content">
                 <div class="col-md-4 col-sm-12">
-                    <a class="index-link" href="?page=configs">
+                    <a class="index-link" href="configs.html">
                         <div class="thumbnail">
                             <img src="./images/config.png" alt="" width="100%" height="100%">
                             <div class="caption">
@@ -29,7 +29,7 @@
                 </div>
 
                 <div class="col-md-4 col-sm-12">
-                    <a class="index-link" href="?page=management">
+                    <a class="index-link" href="management.html">
                         <div class="thumbnail">
                             <img src="./images/botnet.png" alt="">
                             <div class="caption">
@@ -41,7 +41,7 @@
                 </div>
 
                 <div class="col-md-4 col-sm-12">
-                    <a class="index-link" href="?page=monitor">
+                    <a class="index-link" href="monitor.html">
                         <div class="thumbnail">
                             <img src="./images/monitor.png" alt="" >
                             <div class="caption">
@@ -57,7 +57,7 @@
         <div class="row center-row">
             <div class="col-md-9 col-sm-12 center-row-content">
                 <div class="col-md-6 col-sm-12">
-                    <a class="index-link" href="?page=check">
+                    <a class="index-link" href="check.html">
                         <div class="thumbnail">
                             <img src="./images/check.png" alt="" >
                             <div class="caption">
@@ -69,7 +69,7 @@
                 </div>
 
                 <div class="col-md-6 col-sm-12">
-                    <a class="index-link" href="?page=about">
+                    <a class="index-link" href="about.html">
                         <div class="thumbnail">
                             <img src="./images/about.png" alt="" >
                             <div class="caption">


### PR DESCRIPTION
Now that the different pages are not generated anymore on the
fly, the links in the pages should point to the static html files
instead of pointing to `?page=$filename`.
