### PR TITLE
MAINT: Replace the Debian package workflow

### DIFF
--- a/.github/workflows/debian-packaging.yml
+++ b/.github/workflows/debian-packaging.yml
@@ -1,36 +1,34 @@
-#Github Workflow for intelmq-manager
+#Github Workflow to build Debian packages for intelmq-api
 #
-#SPDX-FileCopyrightText: 2020 Birger Schacht
+#SPDX-FileCopyrightText: 2020 IntelMQ Team <intelmq-team@cert.at>
 #SPDX-License-Identifier: AGPL-3.0-or-later
-
-name: "Test intelmq-manager Debian build" 
-
+#
+name: "Build Debian packages"
 on:
   push:
+    branches: [develop, maintenance, master]
   pull_request:
-    branches: [ develop ]
+    branches: [develop, maintenance]
 
 jobs:
-  test:
-    name: Test Debian package build
-    runs-on: ubuntu-20.04
-    # As long as we don't have a lintian clean package,
-    # this should not fail the whole workflow.
-    continue-on-error: true
-
+  build:
+    runs-on: ubuntu-latest
+    name: Build Debian packages
     strategy:
-      fail-fast: false
+      matrix:
+        codename: ['buster', 'bullseye']
 
     steps:
     - name: Checkout repository
       uses: actions/checkout@v2
-    - name: Install dependencies
-      run: |
-        sudo apt-get install dpkg-dev lintian -y
-        sudo apt-get build-dep -y .
-    - name: Run build
-      run: |
-        dpkg-buildpackage -b -us -uc
-    - name: Lint build
-      run: |
-        lintian --profile debian ../*.changes
+
+    - name: Build package
+      run: bash .github/workflows/scripts/debian-package.sh ${{ matrix.codename }}
+
+    - name: Upload artifact
+      if: ${{ github.event_name == 'push' }}
+      uses: actions/upload-artifact@v2
+      with:
+        name: debian-package-${{ matrix.codename }}-${{ github.sha }}
+        path: '~/artifacts'
+        retention-days: 5

--- a/.github/workflows/scripts/debian-package.sh
+++ b/.github/workflows/scripts/debian-package.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: 2020 Birger Schacht
+# SPDX-License-Identifier: AGPL-3.0-or-later
+#
+# Bash script for a github action to build a Debian
+# package in a user-defined Debian container
+
+
+set -x
+set -e
+
+# A list of known Debian releases
+knowncodenames=("stretch" "buster" "bullseye" "stable" "testing")
+
+# We want exactly one argument: the name of the release
+if (( $# != 1 ))
+then
+	>&2 echo "Illegal number of parameters"
+	exit 1
+fi
+
+codename=$1
+
+# check if the releasename is in the list of known Debian distributions
+validcodename=false
+for value in "${knowncodenames[@]}"
+do
+	[[ "$codename" = "$value" ]] && validcodename=true
+done
+
+# If the release name is not valid, simply exit
+unknowncodename () {
+	>&2 echo "Debian distribution not known. Valid arguments are: ${knowncodenames[*]}"
+	exit 1
+}
+
+# Build the package in the container
+build () {
+	codename=$1
+	echo "Building on ${codename}"
+	# run installation in buildah
+
+	ARTIFACTEXTENSIONS=("deb" "xz" "dsc" "buildinfo" "changes")
+	PARENT=$(dirname "${GITHUB_WORKSPACE}")
+	echo "Building on ${codename} in ${GITHUB_WORKSPACE}"
+
+	# fetch and configure the container
+	CONTAINER=$(buildah from docker.io/debian:"${codename}"-slim)
+	buildah config --workingdir "${GITHUB_WORKSPACE}" "${CONTAINER}"
+
+	# install build dependencies in the container
+	BR="buildah run -v ${PARENT}:${PARENT}"
+	${BR} "${CONTAINER}" apt-get update -qq
+	${BR} "${CONTAINER}" apt-get install dpkg-dev lintian -y
+	${BR} "${CONTAINER}" apt-get build-dep -y .
+
+	# this is a hack because intelmq does
+	# not like to be run as root :( :
+	${BR} "${CONTAINER}" chown -R nobody:nogroup "${PARENT}"
+	${BR} --user nobody:nogroup "${CONTAINER}" /bin/sh -c 'dpkg-buildpackage -us -uc -b'
+
+	# create a directory for the artifacts
+	# and copy the relevant files there
+	mkdir -p "${HOME}/artifacts"
+	for extension in "${ARTIFACTEXTENSIONS[@]}"
+	do
+		find "${PARENT}" -type f -name "*.${extension}" -exec cp '{}' "${HOME}/artifacts/" \;
+	done
+}
+
+# check if release name is valid; build if it is, exit if it isn't
+if [ "$validcodename" = true ]
+then
+	build "$codename"
+else
+	unknowncodename
+fi


### PR DESCRIPTION
This replaces the Debian package workflow with the script also used in
the intelmq repository, which builds the package on multiple Debian
distros.
