### PR TITLE
Fixed API paths when saving configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ intelmq_manager/html
 nbproject
 /html/
 *.swp
+.vscode/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 CHANGELOG
 =========
 
+Unreleased changes
+------------------
+
+### Configuration
+- Fixed generating paths with doubled slashes when to save configurations.
 
 3.0.1 (2021-09-02)
 ------------------

--- a/intelmq_manager/static/js/configs.js
+++ b/intelmq_manager/static/js/configs.js
@@ -240,11 +240,11 @@ function save_data_on_files() {
     }
 
     // can't parallelize these due to a race condition from them both touching runtime.yaml; TODO lock file in backend?
-    authenticatedAjax({type: "POST", url: `${API}/runtime`, contentType: "application/json", data: generate_runtime_conf(app.nodes, app.defaults)})
+    authenticatedAjax({type: "POST", url: `${RUNTIME_FILE}`, contentType: "application/json", data: generate_runtime_conf(app.nodes, app.defaults)})
     .done(saveSucceeded)
     .fail(() => alert_error('runtime', ...arguments))
     .then(() =>
-            authenticatedAjax({type: "POST", url: `${API}/positions`, contentType: "application/json", data: generate_positions_conf()})
+            authenticatedAjax({type: "POST", url: `${POSITIONS_FILE}`, contentType: "application/json", data: generate_positions_conf()})
             .done(saveSucceeded)
             .fail(() => alert_error('positions', ...arguments) )
     )


### PR DESCRIPTION
Previously, the Manager was generating API paths
with '//' when calling POST on /runtime and /positions.
This is fixed.

In addition, VS Code dir is added to the .gitignore

Close: #290 