### PR TITLE
Monitor logging

### DIFF
--- a/intelmq_manager/static/js/monitor.js
+++ b/intelmq_manager/static/js/monitor.js
@@ -53,11 +53,13 @@ function redraw() {
 }
 
 function redraw_logs() {
-    $('#log-table').dataTable().fnClearTable();
+    let logTable = $('#log-table').dataTable();
+    let tPage = logTable.api().page();
+    logTable.fnClearTable()
 
     if (bot_logs == {}) {
-        $('#log-table').dataTable().fnAdjustColumnSizing();
-        $('#log-table').dataTable().fnDraw();
+        logTable.fnAdjustColumnSizing();
+        logTable.fnDraw();
         return;
     }
 
@@ -82,7 +84,7 @@ function redraw_logs() {
         log_row.DT_RowClass = LEVEL_CLASS[log_row.log_level];
 
 
-        $('#log-table').dataTable().fnAddData(log_row);
+        logTable.fnAddData(log_row);
         if (has_button) {
             var extended_message_func = message_index => show_extended_message(message_index);
             document.getElementById(`button-extended-message-${index}`).addEventListener('click', function (index) {
@@ -92,9 +94,9 @@ function redraw_logs() {
             }(index))
         }
     }
-
-    $('#log-table').dataTable().fnAdjustColumnSizing();
-    $('#log-table').dataTable().fnDraw();
+    logTable.fnAdjustColumnSizing();
+    logTable.fnDraw();
+    logTable.fnPageChange(tPage);
 }
 
 function redraw_queues() {


### PR DESCRIPTION
Log level selection on Monitor page - this PR fixes an issue where ALL level wouldn't return anything since the backend doesn't have the level ALL. Instead of ALL, CRITICAL is requested in the background as it returns all logs aswell.

also fixes #190 