### PR TITLE
Log level selection: default INFO, remove ALL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ CHANGELOG
 ### Configuration
 - Sort bots alphabetically in side menu (PR#298 by Psych0meter).
 
+### Monitor
+- Default log level is now INFO, consistent with `intelmqctl log`, removed level `ALL` equivalent to `DEBUG` (PR#308 by Sebastian Wagner)
+
 3.3.0 (2024-03-01)
 ------------------
 

--- a/intelmq_manager/templates/monitor.mako
+++ b/intelmq_manager/templates/monitor.mako
@@ -100,10 +100,10 @@
                         <h4 id="logs-panel-title">Logs</h4>
                     </div>
                     <div class="panel-body">
-                        <div class="panel-div">Log Level: <select id="log-level-indicator">
-                                <option value="ALL">All</option>
+                        <div class="panel-div">Log Level:
+                            <select id="log-level-indicator">
                                 <option value="DEBUG">Debug</option>
-                                <option value="INFO">Info</option>
+                                <option value="INFO" selected>Info</option>
                                 <option value="WARNING">Warning</option>
                                 <option value="ERROR">Error</option>
                                 <option value="CRITICAL">Critical</option>


### PR DESCRIPTION
Default log level is now INFO, consistent with `intelmqctl log`, removed level `ALL` equivalent to `DEBUG`