### PR TITLE
fix link to bot documentation page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ CHANGELOG
 
 ### Configuration
 - Sort bots alphabetically in side menu (PR#298 by Psych0meter).
+- Fix link to the bot documentation page (PR#310 by Sebastian Wagner, fixes #307).
 
 3.3.0 (2024-03-01)
 ------------------

--- a/intelmq_manager/static/js/configs.js
+++ b/intelmq_manager/static/js/configs.js
@@ -93,7 +93,7 @@ function load_bots(config) {
         sortedGroupKeys.forEach(key => {
                 sortedGroup[key] = group[key];
         });
-        
+
         for (let bot_name in sortedGroup) {
             let bot = group[bot_name];
             let $bot = $bot_group.find("ul > li:first").clone().appendTo($("ul", $bot_group))
@@ -356,8 +356,7 @@ function fill_bot(id, group, name) {
         insertKeyValue(key, value, BORDER_TYPES.RUNTIME, true);
     }
 
-    const modulename = bot.module.replace(/\./g, "-").replace(/_/g, "-");
-    documentation.href = `https://intelmq.readthedocs.org/en/maintenance/user/bots.html#${modulename}`;
+    documentation.href = `https://docs.intelmq.org/latest/user/bots/#${bot.module}`;
     popup.setAttribute('class', "with-bot");
 }
 


### PR DESCRIPTION
readthedocs -> docs.intelmq.org
and don't replace ._ with -, the anchors all are equal to the module name