### PR TITLE
Avoid multiple requests without a valid token

### DIFF
--- a/intelmq_manager/static/js/static.js
+++ b/intelmq_manager/static/js/static.js
@@ -175,6 +175,10 @@ function show_error(string, permit_html=false) {
 
 function ajax_fail_callback(str) {
     return function (jqXHR, textStatus, message) {
+        if (jqXHR.status === 401) {
+            // Unauthorized access - call logout
+            logout();
+        }
         if (textStatus === "timeout") {
             // this is just a timeout, no other info needed
             show_error(`${str} timeout`);
@@ -498,11 +502,20 @@ function authenticatedGetJson(url) {
 
 function authenticatedAjax(settings) {
     let token = sessionStorage.getItem("login_token");
-    if (token !== null) {
-        settings.headers = {
-            Authorization: token
-        };
+
+    if (token === null) {
+        // Avoid requests without token
+        return $.Deferred().reject({
+            status: 401,
+            statusText: "Unauthorized",
+            responseText: JSON.stringify({message: "No login token available. Please log in."})
+        }, "error", "Unauthorized").promise();
     }
+
+    settings.headers = {
+        Authorization: token
+    };
+
     return $.ajax(settings);
 }
 


### PR DESCRIPTION
This pull request improves client-side authentication handling in the `intelmq_manager/static/js/static.js` file. The main changes focus on preventing unauthorized requests and ensuring users are logged out if their session is no longer valid.

This PR prevents multiple 401 requests issue:
<img width="2557" height="1324" alt="image" src="https://github.com/user-attachments/assets/436fec44-8b84-4ef4-b643-dbec455b18f5" />



Authentication handling improvements:

* In the `authenticatedAjax` function, added a check to prevent AJAX requests from being sent if there is no login token in `sessionStorage`; instead, the function now immediately rejects the request with a 401 Unauthorized error and an appropriate message.
* In the `ajax_fail_callback` function, added logic to automatically call `logout()` if a 401 Unauthorized response is received, ensuring users are logged out when their session expires or becomes invalid.