### PR TITLE
Fixed position of ok/cancel buttons of bot config popup

### DIFF
--- a/intelmq_manager/static/css/sb-admin-2.css
+++ b/intelmq_manager/static/css/sb-admin-2.css
@@ -440,7 +440,6 @@ form {
     bottom: -10px;
     background: #fff;
     padding: 15px 0;
-    border-top: 1px solid #eee;
     margin-top: 10px;
     z-index: 10;
     /* Layout logic */

--- a/intelmq_manager/static/css/sb-admin-2.css
+++ b/intelmq_manager/static/css/sb-admin-2.css
@@ -434,4 +434,32 @@ form {
   display: block;
   box-shadow: 1px 1px 16px rgba(0, 0, 0, 0.2);
 }
+/* 1. Main container remains full width to act as a solid background "shield" */
+#network-popUp .popup-buttons {
+    position: sticky;
+    bottom: -10px;
+    background: #fff;
+    padding: 15px 0;
+    border-top: 1px solid #eee;
+    margin-top: 10px;
+    z-index: 10;
+    /* Layout logic */
+    display: flex;
+    justify-content: center; /* Centers the buttons horizontally */
+    gap: 15px;               /* Space between Cancel and OK */
+    width: 100%;             /* Spans the full width of the popup */
+    /* Added a border-top for better definition */
+    border-top: 1px solid #428bca;
+}
+/* 2. Style for the forms/buttons to make them narrower */
+#network-popUp .popup-buttons form {
+    /* Limit the width of each individual button */
+    width: 120px;            /* Fixed width for a more consistent look */
+    flex: none;              /* Prevents them from stretching to fill the container */
+    margin-bottom: 0;
+    display: block;
+}
+#network-popUp .popup-buttons .btn-block {
+    padding: 2px 12px;
+}
 /*# sourceMappingURL=sb-admin-2.css.map */

--- a/intelmq_manager/templates/configs.mako
+++ b/intelmq_manager/templates/configs.mako
@@ -24,7 +24,7 @@
 <div id="network-popUp" class="without-bot">
     <span id="network-popUp-title">node</span>
     <a id="documentationButton" class="btn btn-default" title="open documentation" href="" target="_blank">
-	<span class="glyphicon glyphicon-question-sign"></span>
+        <span class="glyphicon glyphicon-question-sign"></span>
     </a>
     <table id="network-popUp-fields" class="table table-striped" style="margin:auto;">
         <tr>
@@ -46,7 +46,7 @@
             <td>run_mode</td><td><input id="node-run_mode" value=""></td>
         </tr>
     </table>
-    <div>
+    <div class="popup-buttons">
         <form>
             <input type="button" class="btn-danger btn-block" value="cancel" id="network-popUp-cancel">
         </form>


### PR DESCRIPTION
This pull request improves the user interface for the network popup dialog in the IntelMQ Manager by introducing a new `popup-buttons` container. The changes enhance the layout and styling of the popup's action buttons, making them more visually distinct and user-friendly.

Makes the buttons be always visible:
<img width="1524" height="1072" alt="image" src="https://github.com/user-attachments/assets/38d8de0a-cfda-4523-a7ca-9e3459f7e7e3" />


**UI improvements for network popup:**
* Added a `.popup-buttons` container to the `#network-popUp` dialog, making the button area sticky at the bottom, spanning full width, and visually separated with a border for better definition. [[1]](diffhunk://#diff-93dd8205f38ea89c670d36b7b242c7fd09240944b37e9ff1aa0b3c9bb1265dabR437-R464) [[2]](diffhunk://#diff-f22fbd1ca69ca0a216853a9187d8a48b1b2f25ff5a316f343ce960fd6bf35196L49-R49)
* Styled the forms and buttons inside `.popup-buttons` to have a consistent fixed width, improved spacing, and padding for a more polished and accessible appearance.