### PR TITLE
Added text area multiline to runtime values on bot config

### DIFF
--- a/intelmq_manager/static/js/configs.js
+++ b/intelmq_manager/static/js/configs.js
@@ -397,15 +397,29 @@ function insertKeyValue(key, value, section, allowXButtons, insertAt) {
     let keyCell = new_row.insertCell(0);
     let valueCell = new_row.insertCell(1);
     let xButtonCell = new_row.insertCell(2);
-    let valueInput = document.createElement("input");
+
+    let valueInput;
+
+    // Check the section to decide between textarea or input
+    if (section === BORDER_TYPES.RUNTIME) {
+        valueInput = document.createElement("textarea");
+        valueInput.setAttribute('rows', '2'); // Default height for multiline
+        valueInput.style.resize = 'vertical';
+    } else {
+        valueInput = document.createElement("input");
+        valueInput.setAttribute('type', 'text');
+    }
 
     keyCell.setAttribute('class', 'node-key');
-    keyCell.setAttribute('id', section)
+    keyCell.setAttribute('id', section);
     valueCell.setAttribute('class', 'node-value');
-    valueInput.setAttribute('type', 'text');
+    
     valueInput.setAttribute('id', key);
+    valueInput.className = 'form-control'; // Standard Bootstrap styling
+    valueInput.style.width = '100%';
 
-    if (section === 'generic' && disabledKeys.includes(key) === true) {
+    // Handle disabled keys for 'id' and 'GENERIC' sections
+    if ((section === 'id' || section === BORDER_TYPES.GENERIC) && disabledKeys.includes(key) === true) {
         valueInput.setAttribute('disabled', "true");
     }
 
@@ -426,11 +440,16 @@ function insertKeyValue(key, value, section, allowXButtons, insertAt) {
     valueCell.appendChild(valueInput);
 
     keyCell.innerHTML = key;
+
+    // Format value
+    let displayValue = value;
     if (value !== null && typeof value === "object") {
-        value = JSON.stringify(value);
+        displayValue = JSON.stringify(value, null, 2); // Pretty print JSON
     }
-    if (value !== null) {
-        valueInput.setAttribute('value', value);
+
+    if (displayValue !== null) {
+        // Use .value for both input and textarea
+        valueInput.value = displayValue;
     }
 }
 
@@ -495,9 +514,14 @@ $(document).keydown(function (event) {
         }
     }
     if (event.keyCode === 13 && $('#network-popUp').is(':visible') && $('#network-popUp :focus').length) {
-        // till network popup is not unified with the popupModal function that can handle Enter by default,
-        // let's make it possible to hit "Ok" by Enter as in any standard form
-        $('#network-popUp-ok').click();
+        // If the focused element is a textarea, allow the default behavior (new line)
+        if ($(event.target).is("textarea")) {
+            return; 
+        }
+        // Otherwise, if focus is on a standard input or button, trigger OK
+        if ($('#network-popUp :focus').length) {
+            $('#network-popUp-ok').click();
+        }
     }
 });
 
@@ -512,10 +536,10 @@ function saveFormData() {
     for (let i = 0; i < table.rows.length; i++) {
         let keyCell = table.rows[i].cells[0];
         let valueCell = table.rows[i].cells[1];
-        let valueInput = valueCell.getElementsByTagName('input')[0];
+        // Target both types of elements
+        let valueInput = valueCell.querySelector('input, textarea');
 
-        if (valueInput === undefined)
-            continue;
+        if (!valueInput) continue;
 
         let key = keyCell.innerText;
         let value = null;


### PR DESCRIPTION
This pull request improves the usability and flexibility of the configuration editing UI in `intelmq_manager/static/js/configs.js`. The main enhancements include supporting multiline values for runtime configuration sections, improving the handling and display of JSON values, and refining keyboard accessibility in popups.

Makes all runtime values as text area to improve the bot configuration parameters:
<img width="1374" height="1049" alt="image" src="https://github.com/user-attachments/assets/814b010e-a71b-42f4-b5f7-26b6141781d8" />

As future improvement it could be selective based on some bot definition or documentation.

**UI and Input Improvements:**
- The `insertKeyValue` function now uses a `<textarea>` for runtime section values, enabling users to enter multiline text. For all other sections, a standard `<input type="text">` is used. This makes editing complex or multiline configuration values more user-friendly.
- JSON object values are now pretty-printed in the UI for better readability, and both `<input>` and `<textarea>` elements are handled uniformly when setting their values.

**Accessibility and Form Handling:**
- The Enter key behavior in popups has been improved: pressing Enter in a `<textarea>` now inserts a newline instead of submitting the form, while pressing Enter in other fields still triggers the OK button.
- The `saveFormData` function is updated to correctly retrieve values from both `<input>` and `<textarea>` elements, ensuring that all user input is saved regardless of the input type.

**Other UI Details:**
- Additional Bootstrap styling (`form-control` and full width) is applied to input elements for a more consistent look.
- The logic for disabling keys is clarified and extended to both the 'id' and 'GENERIC' sections.